### PR TITLE
Bugfix: Change value of "main" prop in package.json to gatsby-node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gatsby-source-workable",
   "version": "1.0.1",
   "description": "Gatsby source plugin for loading job openings from Workable",
-  "main": "index.js",
+  "main": "gatsby-node.js",
   "scripts": {
     "build": "babel src --out-dir ."
   },


### PR DESCRIPTION
This line caused 'Unable to find plugin' errors, which broke builds using the plugin and prevented it working.

Changing the main value fixes the issue, but an alternative fix would be to remove the 'main' property entirely, and create an empty index.js file instead (as in many of the official Gatsby plugins).