### PR TITLE
[AXIOS-FIX] Updaste to Axios to remove vulnerabily.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "author": "Bjorn Tegelund <bjorn@tumblbug.com>",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.16.2"
+    "axios": "^0.18.1"
   },
   "devDependencies": {
     "babel-plugin-transform-object-rest-spread": "^6.26.0",


### PR DESCRIPTION
https://www.npmjs.com/advisories/880

Versions of axios prior to 0.18.1 are vulnerable to Denial of Service. If a request exceeds the maxContentLength property, the package prints an error but does not stop the request. This may cause high CPU usage and lead to Denial of Service.